### PR TITLE
Exit with an error if the job is interrupted

### DIFF
--- a/submit.go
+++ b/submit.go
@@ -71,7 +71,7 @@ type (
 		JobConfig              *string  `arg:"--job-conf"`
 		File                   string   `json:"file" ini:"file" arg:"positional"`
 		Parameters             []string `arg:"positional"`
-		NotCompletedExitCode   int64    `arg:"--not-completed-exit-code" help:"Exit code for TERMINATED and FAILED job, default is 0"`
+		InterruptedJobExitCode int64    `arg:"--interrupted-exit-code" help:"Exit code for interrupted job (finised with TERMINATED or FAILED status), default is 0"`
 	}
 )
 
@@ -197,7 +197,7 @@ func main() {
 
 	go func() {
 		job := Loop(client, job)
-		returnCodeChan <- getExitCode(job, args.NotCompletedExitCode)
+		returnCodeChan <- getExitCode(job, args.InterruptedJobExitCode)
 	}()
 
 	// return the channel to a value, and get the defer close channel
@@ -485,18 +485,18 @@ func PrintLog(jobLog []*Log) (lastPrintLog uint64) {
 }
 
 // Process the exit code depending on the job status
-func getExitCode(job *JobStatus, notCompletedExitCode int64) int {
+func getExitCode(job *JobStatus, interruptedJobExitCode int64) int {
 	log.Printf("Job status is : %s", job.Status)
 	codeToReturn := job.ReturnCode
 
 	switch job.Status {
-		case JobStatusCOMPLETED:
-			log.Printf("Job exit code : %v", job.ReturnCode)
-		case JobStatusTERMINATED, JobStatusFAILED:
-			log.Printf("Job is finished, but not completely, fixed exit code : %v", notCompletedExitCode)
-			codeToReturn = notCompletedExitCode
-		default:
-			log.Printf("Status %s not implemeted yet", job.Status)
+	case JobStatusCOMPLETED:
+		log.Printf("Job finished with code : %v", job.ReturnCode)
+	case JobStatusTERMINATED, JobStatusFAILED:
+		log.Printf("Job has been interrupted, spark-submit exiting with code : %v", interruptedJobExitCode)
+		codeToReturn = interruptedJobExitCode
+	default:
+		log.Printf("Status %s not implemeted yet", job.Status)
 	}
 	return int(codeToReturn)
 }

--- a/submit.go
+++ b/submit.go
@@ -197,10 +197,13 @@ func main() {
 	go func() {
 		job := Loop(client, job)
 		log.Printf("Job status is : %s", job.Status)
-		if job.Status == "COMPLETED" {
-			log.Printf("Job exit code : %v", job.ReturnCode)
+		log.Printf("Job exit code : %v", job.ReturnCode)
+		codeToReturn := job.ReturnCode
+		if job.Status == JobStatusTERMINATED || job.Status == JobStatusFAILED {
+			codeToReturn = 44
+			log.Printf("Job is finished, but not completely, fixed exit code : %v", codeToReturn)
 		}
-		returnCodeChan <- int(job.ReturnCode)
+		returnCodeChan <- int(codeToReturn)
 	}()
 
 	// return the channel to a value, and get the defer close channel

--- a/submit.go
+++ b/submit.go
@@ -71,6 +71,7 @@ type (
 		JobConfig              *string  `arg:"--job-conf"`
 		File                   string   `json:"file" ini:"file" arg:"positional"`
 		Parameters             []string `arg:"positional"`
+		NotCompletedExitCode   int64    `arg:"--not-completed-exit-code" help:"Exit code for TERMINATED and FAILED job, default is 0"`
 	}
 )
 
@@ -200,8 +201,8 @@ func main() {
 		log.Printf("Job exit code : %v", job.ReturnCode)
 		codeToReturn := job.ReturnCode
 		if job.Status == JobStatusTERMINATED || job.Status == JobStatusFAILED {
-			codeToReturn = 44
-			log.Printf("Job is finished, but not completely, fixed exit code : %v", codeToReturn)
+			codeToReturn = args.NotCompletedExitCode
+			log.Printf("Job is finished, but not completely, fixed exit code : %v", args.NotCompletedExitCode)
 		}
 		returnCodeChan <- int(codeToReturn)
 	}()

--- a/submit_test.go
+++ b/submit_test.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"data-processing-spark-submit/utils"
 	"encoding/json"
 	"net/http"
-	"time"
-	"data-processing-spark-submit/utils"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	arg "github.com/alexflint/go-arg"
 )
@@ -238,13 +238,13 @@ func TestPrintLog(t *testing.T) {
 }
 
 func TestGetExitCodeCompletedJob(t *testing.T) {
-	notCompletedExitCode := int64(3)
+	interruptedJobExitCode := int64(3)
 
 	JobStatusStruct := &JobStatus{
-		ID:               "dummyId",
-		Name:             "dummyName",
-		Status:           JobStatusCOMPLETED,
-		ReturnCode:       1,
+		ID:         "dummyId",
+		Name:       "dummyName",
+		Status:     JobStatusCOMPLETED,
+		ReturnCode: 1,
 	}
 
 	jobStatus, _ := json.Marshal(JobStatusStruct)
@@ -258,16 +258,16 @@ func TestGetExitCodeCompletedJob(t *testing.T) {
 	}
 
 	jobSubmit := &JobSubmit{
-		ContainerName:    "ovh-odp",
-		Engine:           "spark",
-		Name:             "ovh-odp",
-		Region:           "GRA",
-		EngineVersion:    "2.4.3",
+		ContainerName: "ovh-odp",
+		Engine:        "spark",
+		Name:          "ovh-odp",
+		Region:        "GRA",
+		EngineVersion: "2.4.3",
 	}
 
 	job, _ := client.Submit(ProjectID, jobSubmit)
 
-	returnedExitCode := getExitCode(job, notCompletedExitCode)
+	returnedExitCode := getExitCode(job, interruptedJobExitCode)
 	expectedExitCode := 1
 	if returnedExitCode != expectedExitCode {
 		t.Errorf("Returned exit code (%d) does not match expected exit code (%d)", returnedExitCode, expectedExitCode)
@@ -279,12 +279,12 @@ func TestGetExitCodeCompletedJob(t *testing.T) {
 }
 
 func TestGetExitCodeTerminatedJob(t *testing.T) {
-	notCompletedExitCode := int64(3)
+	interruptedJobExitCode := int64(3)
 
 	JobStatusStruct := &JobStatus{
-		ID:               "dummyId",
-		Name:             "dummyName",
-		Status:           JobStatusTERMINATED,
+		ID:     "dummyId",
+		Name:   "dummyName",
+		Status: JobStatusTERMINATED,
 		// No ReturnCode given
 	}
 
@@ -299,16 +299,16 @@ func TestGetExitCodeTerminatedJob(t *testing.T) {
 	}
 
 	jobSubmit := &JobSubmit{
-		ContainerName:    "ovh-odp",
-		Engine:           "spark",
-		Name:             "ovh-odp",
-		Region:           "GRA",
-		EngineVersion:    "2.4.3",
+		ContainerName: "ovh-odp",
+		Engine:        "spark",
+		Name:          "ovh-odp",
+		Region:        "GRA",
+		EngineVersion: "2.4.3",
 	}
 
 	job, _ := client.Submit(ProjectID, jobSubmit)
 
-	returnedExitCode := getExitCode(job, notCompletedExitCode)
+	returnedExitCode := getExitCode(job, interruptedJobExitCode)
 	expectedExitCode := 3
 
 	if returnedExitCode != expectedExitCode {


### PR DESCRIPTION
### 🩹 Problem
When a spark job fails with the status "_TERMINATED_" (when manually killed, for example) or "_FAILED_", the ovh-spark-submit returns 0, and Airflow interprets this output code as a success and starts further processing.

### 🤖 Proposal
The OVH API does not return an exit code for jobs with this status, and without this exit code the instance of the `JobStatus` struct uses the [zero-value](https://go.dev/ref/spec#The_zero_value) for the `ReturnCode`. An exit code of 0 is therefore returned. I propose to parameterize the desired exit code in the case of these two statuses with `--not-completed-exit-code NOT-COMPLETED-EXIT-CODE`.
